### PR TITLE
Adds a preference for cusor reset behavior

### DIFF
--- a/Preferences.py
+++ b/Preferences.py
@@ -19,8 +19,18 @@ class RightMouseNavigationPreferences(bpy.types.AddonPreferences):
         max=200
     )
 
+    reset_cursor_on_exit: bpy.props.BoolProperty(
+        name="Reset Cursor on Exit",
+        description="After exiting navigation, this determines if the cursor resets to where RMB was clicked (if checked) or stays in the center (if unchecked)",
+        default=False
+    )
+
     def draw(self, context):
         layout = self.layout
-        row = layout.row()
-        row.prop(self, 'timepreference')
-        row.prop(self, 'distancepreference')
+
+        layout.label(text="Menu Trigger Preferences")
+        layout.prop(self, 'timepreference')
+        layout.prop(self, 'distancepreference')
+
+        layout.label(text="Cursor Preferences")
+        layout.prop(self, 'reset_cursor_on_exit')

--- a/Preferences.py
+++ b/Preferences.py
@@ -22,7 +22,7 @@ class RightMouseNavigationPreferences(bpy.types.AddonPreferences):
     reset_cursor_on_exit: bpy.props.BoolProperty(
         name="Reset Cursor on Exit",
         description="After exiting navigation, this determines if the cursor resets to where RMB was clicked (if checked) or stays in the center (if unchecked)",
-        default=False
+        default=True
     )
 
     def draw(self, context):

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Mouse Wheel to adjust Viewport Move Speed (while Right Mouse is held)
 
 You can adjust the threshold for when you navigate/open menus by adjusting the time the mouse button is held, or distance the cursor travels in __Edit__ > __Preferences__ > __Addons__ > __View 3D: Right Mouse Navigation__ by clicking the dropdown arrow and tweaking the values there.
 
+Additionally, in the settings, you can change the cursor resetting behavior. By default, the cursor will stay in the center after navigation exit, matching where the navigation crosshair was. If you want to instead set the cursor back to the location where you initally clicked Right Mouse Button (old behavior before 0.1.9), you can enable the setting.
+
 ## Acknowledgements and Thanks
 
 Big thanks to __Biaru__ for fixing the context menu/cursor location bug, and adding a 'mouse movement' threshold, in addition to the time threshold for fine-tuning when you navigate vs open the context menu!

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Mouse Wheel to adjust Viewport Move Speed (while Right Mouse is held)
 
 You can adjust the threshold for when you navigate/open menus by adjusting the time the mouse button is held, or distance the cursor travels in __Edit__ > __Preferences__ > __Addons__ > __View 3D: Right Mouse Navigation__ by clicking the dropdown arrow and tweaking the values there.
 
-Additionally, in the settings, you can change the cursor resetting behavior. By default, the cursor will stay in the center after navigation exit, matching where the navigation crosshair was. If you want to instead set the cursor back to the location where you initally clicked Right Mouse Button (old behavior before 0.1.9), you can enable the setting.
+Additionally, in the settings, you can change the cursor resetting behavior. By default, the cursor will snap back to the location where you initally clicked Right Mouse Button, after navigation exits. If you would rather the cursor stay in the center (where the navigation crosshair is) after navigation, you can disable the setting.
 
 ## Acknowledgements and Thanks
 

--- a/RightMouseNavigation.py
+++ b/RightMouseNavigation.py
@@ -29,13 +29,23 @@ class BLUI_OT_right_mouse_navigation(bpy.types.Operator):
 
         # The _finished Boolean acts as a flag to exit the modal loop, 
         # it is not made True until after the cancel function is called
-        if self._finished == True:
-            # Reset blender window cursor to previous position
-            context.window.cursor_warp(self.view_x, self.view_y)
-            # Reset Windows OS cursor to previous position
-            ctypes.windll.user32.SetCursorPos(self.mouse_x, self.mouse_y)
-            if self._callMenu == True:
+        if self._finished:
+
+            def reset_cursor():
+                # Reset blender window cursor to previous position
+                context.window.cursor_warp(self.view_x, self.view_y)
+                # Reset Windows OS cursor to previous position
+                ctypes.windll.user32.SetCursorPos(self.mouse_x, self.mouse_y)
+
+            if self._callMenu:
+                # Always reset the cursor if menu is called, as that implies a canceled navigation
+                reset_cursor()
                 self.callMenu(context)
+            else:
+                # Exit of a full navigation. Only reset the cursor if the preference (default False) is enabled
+                if addon_prefs.reset_cursor_on_exit:
+                    reset_cursor()
+                
             return {'CANCELLED'}
             
         if context.space_data.type == 'VIEW_3D':

--- a/__init__.py
+++ b/__init__.py
@@ -2,7 +2,7 @@ bl_info = {
     'name': 'Right Mouse Navigation',
     'category': 'View 3D',
     'author': 'Spectral Vectors',
-    'version': (0, 1, 8),
+    'version': (0, 1, 9),
     'blender': (2, 90, 0),
     'location': '3D Viewport',
     "description": "Enables Right Mouse Viewport Navigation"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6182419/185260901-2f607e06-afe4-4781-8ffa-27cd43ce80b9.png)

This adds a preference to cause the cursor to stay in the center (where the navigation crosshair is) after exiting navigation, initally based on issue https://github.com/SpectralVectors/RightMouseNavigation/issues/14

My initial stab at just commenting out the cursor resetting had a bug-- the cursor would stay in the center even when a menu was opened, causing the menu to be far away from the cursor.

To fix that, I added in a check that only resets the cursor if the preference is enabled AND navigation wasn't cancelled, leading to a menu opening. ***Now, the cursor is properly positioned on the menu if a menu is opened.***

@SpectralVectors I strongly believe that not resetting the cursor should be the default behavior, which is how I've set it up in the PR. In the issue, you said users requested the resetting
> because users found it jarring to have their cursor snapped to the center of the screen after each move operation.

My gut is saying that they found the offset between menu and mouse jarring, not that the majority of them disliked the cursor staying in the center after actual navigation.

As a new user of this, coming from Unity (and using scroll wheel click to get somewhat similar behavior of invoking navigation in blender before I found this plugin), the resetting of the cursor was very jarring. I'd be in navigation for a few seconds, and then when I released my cursor would jump to what felt like a random screen location (as the context of me having my mouse there before was no longer relevant). It was jarring enough that it almost stopped me from using the plugin.

That being said, it's your project, so if you feel really strongly about it, I can of course change the default behavior, though I'd like to have a discussion first if possible.

Anyhow, this is my first blender plugin change, so if I did anything wrong please let me know! Thanks for making this tool, it's really awesome.
