### PR TITLE
Keymap, Cursor Reset Fix, Distance Removed

### DIFF
--- a/Preferences.py
+++ b/Preferences.py
@@ -1,16 +1,23 @@
 import bpy
+from bpy.props import (
+    BoolProperty,
+    FloatProperty,
+)
+from bpy.types import AddonPreferences
 
 
 def update_node_keymap(self, context):
     wm = context.window_manager
-    kc = wm.keyconfigs.user
-    for key in kc.keymaps['Node Editor'].keymap_items:
+    active_kc = wm.keyconfigs.active
+    for key in active_kc.keymaps['Node Editor'].keymap_items:
         if (
             key.idname == "wm.call_menu"
             and key.type == "RIGHTMOUSE"
         ):
             key.active = not key.active
 
+    addon_kc = wm.keyconfigs.addon
+    for key in addon_kc.keymaps['Node Editor'].keymap_items:
         if (
             key.idname == "blui.right_mouse_navigation"
             and key.type == "RIGHTMOUSE"
@@ -18,32 +25,25 @@ def update_node_keymap(self, context):
             key.active = not key.active
 
 
-class RightMouseNavigationPreferences(bpy.types.AddonPreferences):
+class RightMouseNavigationPreferences(AddonPreferences):
     bl_idname = __package__
 
-    time: bpy.props.FloatProperty(
+    time: FloatProperty(
         name="Time Threshold",
         description="How long you have hold right mouse to open menu",
-        default=0.3,
+        default=1.0,
         min=0.1,
-        max=2
+        max=10,
     )
 
-    distance: bpy.props.FloatProperty(
-        name="Distance Threshold",
-        description="How far you have to move the mouse to trigger navigation",
-        default=20,
-        min=1,
-        max=200
-    )
-
-    reset_cursor_on_exit: bpy.props.BoolProperty(
+    reset_cursor_on_exit: BoolProperty(
         name="Reset Cursor on Exit",
-        description="After exiting navigation, this determines if the cursor resets to where RMB was clicked (if checked) or stays in the center (if unchecked)",
-        default=True
+        description="After exiting navigation, this determines if the cursor stays "
+        "where RMB was clicked (if unchecked) or resets to the center (if checked)",
+        default=False,
     )
 
-    enable_for_node_editors: bpy.props.BoolProperty(
+    enable_for_node_editors: BoolProperty(
         name="Enable for Node Editors",
         description="Right Mouse will pan the view / open the Node Add/Search Menu",
         default=False,
@@ -55,9 +55,7 @@ class RightMouseNavigationPreferences(bpy.types.AddonPreferences):
 
         box = layout.box()
         box.label(text="Menu / Movement", icon='DRIVER_DISTANCE')
-        row = box.row()
-        row.prop(self, 'time')
-        row.prop(self, 'distance')
+        box.prop(self, 'time')
 
         row = layout.row()
         box = row.box()

--- a/__init__.py
+++ b/__init__.py
@@ -1,17 +1,16 @@
+from .Preferences import RightMouseNavigationPreferences
+from .RightMouseNavigation import BLUI_OT_right_mouse_navigation
+import bpy
+
 bl_info = {
     'name': 'Right Mouse Navigation',
     'category': '3D View',
     'author': 'Spectral Vectors',
-    'version': (2, 1, 0),
+    'version': (2, 2, 0),
     'blender': (2, 90, 0),
     'location': '3D Viewport, Node Editor',
     "description": "Enables Right Mouse Viewport Navigation"
-    }
-
-import bpy
-
-from .RightMouseNavigation import BLUI_OT_right_mouse_navigation
-from .Preferences import RightMouseNavigationPreferences        
+}
 
 
 addon_keymaps = []
@@ -22,50 +21,41 @@ def register():
         bpy.utils.register_class(RightMouseNavigationPreferences)
         bpy.utils.register_class(BLUI_OT_right_mouse_navigation)
 
-        register_keymaps()    
-
-
-def register_keymaps():
-    keyconfig = bpy.context.window_manager.keyconfigs
-    areas = 'Window', 'Text', 'Object Mode', '3D View', 'Image', 'Node Editor'
-
-    if not all(i in keyconfig.active.keymaps for i in areas):
-        bpy.app.timers.register(register_keymaps, first_interval=0.1)
-
-    else:
-
         wm = bpy.context.window_manager
-        kc = wm.keyconfigs.user
+        addon_kc = wm.keyconfigs.addon
 
-        km = kc.keymaps['3D View']
+        km = addon_kc.keymaps.new(name='3D View', space_type='VIEW_3D')
         kmi = km.keymap_items.new(
             "blui.right_mouse_navigation",
             'RIGHTMOUSE',
             'PRESS'
-            )
+        )
         kmi.active = True
 
-        km2 = kc.keymaps['Node Editor']
+        km2 = addon_kc.keymaps.new(name='Node Editor', space_type='NODE_EDITOR')
         kmi2 = km2.keymap_items.new(
             "blui.right_mouse_navigation",
             'RIGHTMOUSE',
             'PRESS'
-            )
+        )
         kmi2.active = False
 
         addon_keymaps.append((km, kmi, km2, kmi2))
 
-        menumodes = ["Object Mode", "Mesh", "Curve", "Armature", "Metaball", "Lattice", "Font", "Pose"]
+        active_kc = wm.keyconfigs.active
+
+        menumodes = ["Object Mode", "Mesh", "Curve",
+                     "Armature", "Metaball", "Lattice", "Font", "Pose"]
         panelmodes = ["Vertex Paint", "Weight Paint", "Image Paint", "Sculpt"]
 
         # These Modes all call standard menus
         # "Object Mode", "Mesh", "Curve", "Armature", "Metaball", "Lattice",
         # "Font", "Pose"
         for i in menumodes:
-            for key in kc.keymaps[i].keymap_items:
+            for key in active_kc.keymaps[i].keymap_items:
                 if (
-                    key.idname == "wm.call_menu"
-                    and key.type == "RIGHTMOUSE"
+                    # key.idname == "wm.call_menu"
+                    key.type == "RIGHTMOUSE"
                     and key.active
                 ):
                     key.active = False
@@ -73,7 +63,7 @@ def register_keymaps():
         # These Modes call panels instead of menus
         # "Vertex Paint", "Weight Paint", "Image Paint", "Sculpt"
         for i in panelmodes:
-            for key in kc.keymaps[i].keymap_items:
+            for key in active_kc.keymaps[i].keymap_items:
                 if (
                     key.idname == "wm.call_panel"
                     and key.type == "RIGHTMOUSE"
@@ -81,15 +71,15 @@ def register_keymaps():
                 ):
                     key.active = False
 
-        # Changing the Walk Modal Map        
-        for key in kc.keymaps["View3D Walk Modal"].keymap_items:
+        # Changing the Walk Modal Map
+        for key in active_kc.keymaps["View3D Walk Modal"].keymap_items:
             if (
                 key.propvalue == "CANCEL"
                 and key.type == "RIGHTMOUSE"
                 and key.active
             ):
                 key.active = False
-        for key in kc.keymaps["View3D Walk Modal"].keymap_items:
+        for key in active_kc.keymaps["View3D Walk Modal"].keymap_items:
             if (
                 key.propvalue == "CONFIRM"
                 and key.type == "LEFTMOUSE"
@@ -97,31 +87,32 @@ def register_keymaps():
             ):
                 key.type = "RIGHTMOUSE"
                 key.value = "RELEASE"
-        pass
 
 
 def unregister():
     if not bpy.app.background:
+
         bpy.utils.unregister_class(BLUI_OT_right_mouse_navigation)
         bpy.utils.unregister_class(RightMouseNavigationPreferences)
 
         wm = bpy.context.window_manager
-        kc = wm.keyconfigs.user
+        active_kc = wm.keyconfigs.active
 
-        for key in kc.keymaps['Node Editor'].keymap_items:
+        for key in active_kc.keymaps['Node Editor'].keymap_items:
             if (key.idname == 'blui.right_mouse_navigation'):
-                kc.keymaps['Node Editor'].keymap_items.remove(key)
+                active_kc.keymaps['Node Editor'].keymap_items.remove(key)
 
         addon_keymaps.clear()
 
-        menumodes = ["Object Mode", "Mesh", "Curve", "Armature", "Metaball", "Lattice", "Font", "Pose", "Node Editor"]
+        menumodes = ["Object Mode", "Mesh", "Curve", "Armature",
+                     "Metaball", "Lattice", "Font", "Pose", "Node Editor"]
         panelmodes = ["Vertex Paint", "Weight Paint", "Image Paint", "Sculpt"]
 
         # Reactivating menus
         # "Object Mode", "Mesh", "Curve", "Armature", "Metaball", "Lattice",
         # "Font", "Pose"
         for i in menumodes:
-            for key in kc.keymaps[i].keymap_items:
+            for key in active_kc.keymaps[i].keymap_items:
                 if (
                     key.idname == "wm.call_menu"
                     and key.type == "RIGHTMOUSE"
@@ -129,29 +120,30 @@ def unregister():
                     key.active = True
 
         # Reactivating panels
-        # "Vertex Paint", "Weight Paint", "Image Paint", "Sculpt"    
+        # "Vertex Paint", "Weight Paint", "Image Paint", "Sculpt"
         for i in panelmodes:
-            for key in kc.keymaps[i].keymap_items:
+            for key in active_kc.keymaps[i].keymap_items:
                 if (
                     key.idname == "wm.call_panel"
                     and key.type == "RIGHTMOUSE"
                 ):
                     key.active = True
 
-        # Changing the Walk Modal Map back     
-        for key in kc.keymaps["View3D Walk Modal"].keymap_items:
+        # Changing the Walk Modal Map back
+        for key in active_kc.keymaps["View3D Walk Modal"].keymap_items:
             if (
                 key.propvalue == "CANCEL"
                 and key.type == "RIGHTMOUSE"
             ):
                 key.active = True
-        for key in kc.keymaps["View3D Walk Modal"].keymap_items:
+        for key in active_kc.keymaps["View3D Walk Modal"].keymap_items:
             if (
                 key.propvalue == "CONFIRM"
                 and key.type == "RIGHTMOUSE"
             ):
                 key.type = "LEFTMOUSE"
                 key.value = "PRESS"
+
 
 if __name__ == "__package__":
     register()


### PR DESCRIPTION
Fixed the keymap registration (again, and hopefully for the last time), I had been trying to make all the keymap changes on a single map, not realizing that I should have been switching between the addon keymap that I had created and the user's active keymap.

Cursor Reset behavior seems to have been updated in Blender so that the cursor will remember its last screen position. This is the 'patched' behavior that this addon previously had implemented, which made the Cursor Reset setting redundant. I have implemented the previous 'cursor centering' behavior as the new 'Cursor Reset' behavior. The settings have flipped, but now the old behavior remains.

The distance threshold did not have any effect on the addon, so it has been removed. If this is something that is missed, I can see about reimplementing it.