### PR TITLE
Blender 4.2 compatibility update

### DIFF
--- a/Preferences.py
+++ b/Preferences.py
@@ -19,7 +19,7 @@ def update_node_keymap(self, context):
     addon_kc = wm.keyconfigs.addon
     for key in addon_kc.keymaps['Node Editor'].keymap_items:
         if (
-            key.idname == "blui.right_mouse_navigation"
+            key.idname == "rmn.right_mouse_navigation"
             and key.type == "RIGHTMOUSE"
         ):
             key.active = not key.active

--- a/RightMouseNavigation.py
+++ b/RightMouseNavigation.py
@@ -4,9 +4,9 @@ import ctypes
 import sys
 
 
-class BLUI_OT_right_mouse_navigation(Operator):
+class RMN_OT_right_mouse_navigation(Operator):
     """Timer that decides whether to display a menu after Right Click"""
-    bl_idname = "blui.right_mouse_navigation"
+    bl_idname = "rmn.right_mouse_navigation"
     bl_label = "Right Mouse Navigation"
     bl_options = {'REGISTER', 'UNDO'}
 
@@ -102,7 +102,10 @@ class BLUI_OT_right_mouse_navigation(Operator):
     def callMenu(self, context):
         if context.space_data.type == 'NODE_EDITOR':
             if context.space_data.node_tree:
-                bpy.ops.wm.search_single_menu('INVOKE_DEFAULT', menu_idname='NODE_MT_add')
+                if context.space_data.node_tree.nodes.active is not None and context.space_data.node_tree.nodes.active.select:
+                    bpy.ops.wm.call_menu(name='NODE_MT_context_menu')
+                else:
+                    bpy.ops.wm.search_single_menu('INVOKE_DEFAULT', menu_idname='NODE_MT_add')
         else:
             try:
                 bpy.ops.wm.call_menu(name=self.menu_by_mode[context.mode])

--- a/__init__.py
+++ b/__init__.py
@@ -1,17 +1,6 @@
 from .Preferences import RightMouseNavigationPreferences
-from .RightMouseNavigation import BLUI_OT_right_mouse_navigation
+from .RightMouseNavigation import RMN_OT_right_mouse_navigation
 import bpy
-
-bl_info = {
-    'name': 'Right Mouse Navigation',
-    'category': '3D View',
-    'author': 'Spectral Vectors',
-    'version': (2, 2, 0),
-    'blender': (2, 90, 0),
-    'location': '3D Viewport, Node Editor',
-    "description": "Enables Right Mouse Viewport Navigation"
-}
-
 
 addon_keymaps = []
 
@@ -19,14 +8,14 @@ addon_keymaps = []
 def register():
     if not bpy.app.background:
         bpy.utils.register_class(RightMouseNavigationPreferences)
-        bpy.utils.register_class(BLUI_OT_right_mouse_navigation)
+        bpy.utils.register_class(RMN_OT_right_mouse_navigation)
 
         wm = bpy.context.window_manager
         addon_kc = wm.keyconfigs.addon
 
         km = addon_kc.keymaps.new(name='3D View', space_type='VIEW_3D')
         kmi = km.keymap_items.new(
-            "blui.right_mouse_navigation",
+            "rmn.right_mouse_navigation",
             'RIGHTMOUSE',
             'PRESS'
         )
@@ -34,7 +23,7 @@ def register():
 
         km2 = addon_kc.keymaps.new(name='Node Editor', space_type='NODE_EDITOR')
         kmi2 = km2.keymap_items.new(
-            "blui.right_mouse_navigation",
+            "rmn.right_mouse_navigation",
             'RIGHTMOUSE',
             'PRESS'
         )
@@ -92,14 +81,14 @@ def register():
 def unregister():
     if not bpy.app.background:
 
-        bpy.utils.unregister_class(BLUI_OT_right_mouse_navigation)
+        bpy.utils.unregister_class(RMN_OT_right_mouse_navigation)
         bpy.utils.unregister_class(RightMouseNavigationPreferences)
 
         wm = bpy.context.window_manager
         active_kc = wm.keyconfigs.active
 
         for key in active_kc.keymaps['Node Editor'].keymap_items:
-            if (key.idname == 'blui.right_mouse_navigation'):
+            if (key.idname == 'rmn.right_mouse_navigation'):
                 active_kc.keymaps['Node Editor'].keymap_items.remove(key)
 
         addon_keymaps.clear()

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,0 +1,73 @@
+schema_version = "1.0.0"
+
+# Example of manifest file for a Blender extension
+# Change the values according to your extension
+id = "right_mouse_navigation"
+version = "2.3.3"
+name = "Right Mouse Navigation"
+tagline = "Game Engine-style viewport & node graph navigation"
+maintainer = "Spectral Vectors"
+# Supported types: "add-on", "theme"
+type = "add-on"
+
+# Optional link to documentation, support, source files, etc
+website = "https://github.com/SpectralVectors/RightMouseNavigation"
+
+# Optional list defined by Blender and server, see:
+# https://docs.blender.org/manual/en/dev/advanced/extensions/tags.html
+tags = ["Animation", "Sequencer"]
+
+blender_version_min = "4.2.0"
+# # Optional: Blender version that the extension does not support, earlier versions are supported.
+# # This can be omitted and defined later on the extensions platform if an issue is found.
+# blender_version_max = "5.1.0"
+
+# License conforming to https://spdx.org/licenses/ (use "SPDX: prefix)
+# https://docs.blender.org/manual/en/dev/advanced/extensions/licenses.html
+license = [
+  "SPDX:GPL-2.0-or-later",
+]
+# Optional: required by some licenses.
+# copyright = [
+#   "2002-2024 Developer Name",
+#   "1998 Company Name",
+# ]
+
+# Optional list of supported platforms. If omitted, the extension will be available in all operating systems.
+# platforms = ["windows-x64", "macos-arm64", "linux-x64"]
+# Other supported platforms: "windows-arm64", "macos-x64"
+
+# Optional: bundle 3rd party Python modules.
+# https://docs.blender.org/manual/en/dev/advanced/extensions/python_wheels.html
+# wheels = [
+#   "./wheels/hexdump-3.3-py3-none-any.whl",
+#   "./wheels/jsmin-3.0.1-py3-none-any.whl",
+# ]
+
+# # Optional: add-ons can list which resources they will require:
+# # * files (for access of any filesystem operations)
+# # * network (for internet access)
+# # * clipboard (to read and/or write the system clipboard)
+# # * camera (to capture photos and videos)
+# # * microphone (to capture audio)
+# #
+# # If using network, remember to also check `bpy.app.online_access`
+# # https://docs.blender.org/manual/en/dev/advanced/extensions/addons.html#internet-access
+# #
+# # For each permission it is important to also specify the reason why it is required.
+# # Keep this a single short sentence without a period (.) at the end.
+# # For longer explanations use the documentation or detail page.
+#
+# [permissions]
+# network = "Need to sync motion-capture data to server"
+# files = "Import/export FBX from/to disk"
+# clipboard = "Copy and paste bone transforms"
+
+# Optional: build settings.
+# https://docs.blender.org/manual/en/dev/advanced/extensions/command_line_arguments.html#command-line-args-extension-build
+# [build]
+# paths_exclude_pattern = [
+#   "__pycache__/",
+#   "/.git/",
+#   "/*.zip",
+# ]


### PR DESCRIPTION
Removed `bl_info`, replaced with `blender_manifest.toml` Updated Node Editor mode so that when a node is selected you will open the default context menu, but when no nodes are selected you will open the node search. I feel this is a practicality update, and the alternative would be an additional keybind, like `Ctrl + Right Mouse` to get the standard context menu. If you have a strong opinion about this, create an issue and solutions can be discussed. Thanks!