### PR TITLE
Added Preference for Resetting to Orthographic on Exit (default True).

### DIFF
--- a/Preferences.py
+++ b/Preferences.py
@@ -37,6 +37,13 @@ class RightMouseNavigationPreferences(AddonPreferences):
         default=False,
     )
 
+    return_to_ortho_on_exit: BoolProperty(
+        name="Return to Orthographic on Exit",
+        description="After exiting navigation, this determines if the Viewport "
+        "returns to Orthographic view (if checked) or remains in Perspective view (if unchecked)",
+        default=True,
+    )
+
     enable_for_node_editors: BoolProperty(
         name="Enable for Node Editors",
         description="Right Mouse will pan the view / open the Node Add/Search Menu",
@@ -58,3 +65,8 @@ class RightMouseNavigationPreferences(AddonPreferences):
         box = row.box()
         box.label(text="Node Editor", icon="NODETREE")
         box.prop(self, "enable_for_node_editors")
+        
+        row = layout.row()
+        box = row.box()
+        box.label(text="View", icon="VIEW3D")
+        box.prop(self, "return_to_ortho_on_exit")

--- a/RightMouseNavigation.py
+++ b/RightMouseNavigation.py
@@ -44,7 +44,7 @@ class RMN_OT_right_mouse_navigation(Operator):
             if bpy.context.region_data.is_perspective:
                 self._ortho = False
             else:
-                self._back_to_ortho = True
+                self._back_to_ortho = addon_prefs.return_to_ortho_on_exit
 
         # The _finished Boolean acts as a flag to exit the modal loop,
         # it is not made True until after the cancel function is called


### PR DESCRIPTION
I was going to report it as an issue, but found that it was actually a fix that someone requested.
I made it into a preference instead so it can be turned off.
https://github.com/SpectralVectors/RightMouseNavigation/issues/17#issuecomment-1652817722