### PR TITLE
Add orbit navigation mode option

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -131,16 +131,20 @@ class RMN_OT_right_mouse_navigation(Operator):
         addon_prefs = preferences.addons[__package__].preferences
         enable_nodes = addon_prefs.enable_for_node_editors
         disable_camera = addon_prefs.disable_camera_navigation
+        navigation_mode = addon_prefs.navigation_mode
 
         space_type = context.space_data.type
 
         # Execute is the first thing called in our operator, so we start by
-        # calling Blender's built-in Walk Navigation
+        # calling the appropriate navigation based on user preference
         if space_type == "VIEW_3D":
             view = context.space_data.region_3d.view_perspective
             if not (view == "CAMERA" and disable_camera):
                 try:
-                    bpy.ops.view3d.walk("INVOKE_DEFAULT")
+                    if navigation_mode == "ORBIT":
+                        bpy.ops.view3d.rotate("INVOKE_DEFAULT")
+                    else:
+                        bpy.ops.view3d.walk("INVOKE_DEFAULT")
                     # Adding the timer and starting the loop
                     wm = context.window_manager
                     self._timer = wm.event_timer_add(0.1, window=context.window)

--- a/preferences.py
+++ b/preferences.py
@@ -1,6 +1,7 @@
 import bpy
 from bpy.props import (
     BoolProperty,
+    EnumProperty,
     FloatProperty,
 )
 from bpy.types import AddonPreferences
@@ -51,6 +52,16 @@ def update_node_keymap(self, context):
 class RightMouseNavigationPreferences(AddonPreferences):
     bl_idname = __package__
 
+    navigation_mode: EnumProperty(
+        name="Navigation Mode",
+        description="Choose how right-click drag navigates the viewport",
+        items=[
+            ("WALK", "Walk", "First-person walk navigation (default Blender behavior)"),
+            ("ORBIT", "Orbit", "Orbit around view center (like middle-mouse-button)"),
+        ],
+        default="WALK",
+    )
+
     time: FloatProperty(
         name="Time Threshold",
         description="How long you have hold right mouse to open menu",
@@ -98,8 +109,13 @@ class RightMouseNavigationPreferences(AddonPreferences):
 
         row = layout.row()
         box = row.box()
+        box.label(text="Navigation", icon="ORIENTATION_GIMBAL")
+        box.prop(self, "navigation_mode")
+        box = row.box()
         box.label(text="Menu / Movement", icon="DRIVER_DISTANCE")
         box.prop(self, "time")
+
+        row = layout.row()
         box = row.box()
         box.label(text="Node Editor", icon="NODETREE")
         box.prop(self, "enable_for_node_editors")


### PR DESCRIPTION
## Summary
- Adds a new "Navigation Mode" preference to choose between Walk and Orbit navigation
- Walk mode: First-person walk navigation (existing default behavior)
- Orbit mode: Orbit around view center, similar to middle-mouse-button behavior

This allows users who prefer turntable/orbit-style navigation to use right-click drag for orbiting instead of walk navigation.

## Changes
- `preferences.py`: Added `navigation_mode` EnumProperty and UI
- `operators.py`: Check preference and call `view3d.rotate` for Orbit mode